### PR TITLE
Fix MAGI-1 guidance wiring and preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Other models can be pretty easily integrated. Just compute a reward score with t
 ### Quick Start (Single Prompt I2V)
 ```bash
 python generate_magi1.py \
-    --config_file ./MAGI-1/configs/inference_config.json \
+    --config_file ./MAGI-1/example/24B/24B_base_config.json \
     --prompt "A ball falls from the table onto the floor" \
     --init_image ./example/0001_switch-frames_anyFPS_perspective-left_trimmed-ball-and-block-fall.jpg \
     --output_path ./results/output.mp4 \

--- a/generation/generate_i2v_magi1_multinode.sh
+++ b/generation/generate_i2v_magi1_multinode.sh
@@ -44,6 +44,7 @@ SEED_LIST=(42)
 
 GUIDANCE_STEP_PATTERN="0x5,1x45"
 GUIDANCE_LR_PATTERNS=("0.001x50")
+GUIDANCE_SCALE=0.001
 GUIDANCE_FREQUENCY=1
 
 # CFG scale values for classifier-free guidance ablation
@@ -53,7 +54,7 @@ CFG_SCALES=("6.0")
 GUIDANCE_RANGES=("0 0")
 
 # Path to MAGI-1 config file
-MAGI1_CONFIG_FILE="./MAGI-1/configs/inference_config.json"
+MAGI1_CONFIG_FILE="./MAGI-1/example/24B/24B_base_config.json"
 
 # JSON batch describing entries with input image/video, prompt, and output path
 # Add or remove batch JSON files as needed
@@ -135,6 +136,7 @@ for SAMPLE_METHOD in "${SAMPLE_METHODS[@]}"; do
                                 --height 480 \
                                 --width 720 \
                                 --cfg_scale $CFG_SCALE \
+                                --guidance_scale $GUIDANCE_SCALE \
                                 --vjepa_variant $VJEPA_VARIANT \
                                 --vjepa_img_size $VJEPA_IMG_SIZE \
                                 --vjepa_masking_mode $VJEPA_MASKING_MODE \

--- a/generation/generate_i2v_magi1_multinode.sh
+++ b/generation/generate_i2v_magi1_multinode.sh
@@ -34,8 +34,8 @@ NODE_ID=${SLURM_ARRAY_TASK_ID}        # Current node ID (0-3)
 
 echo "Starting node ${NODE_ID} of ${NUM_NODES} (GPUs per node: ${NUM_GPUS_PER_NODE}, Total GPUs: ${TOTAL_GPUS})"
 
-# Define hyperparameter triplets (slice_window_size, vjepa_context_frames, slice_stride)
-# For vanilla: these are harmless; for guidance: they control the sliding window
+# Legacy/rejection-sampling hyperparameter triplets
+# The current MAGI guidance path ignores these and only consumes guidance_scale/frequency/backbone.
 TRIPLETS=(
     "16 8 8"   # window=16, context_frames=8, stride=8
 )
@@ -86,17 +86,29 @@ mkdir -p "$OUTPUT_FOLDER"
 for BATCH_JSON in "${BATCH_JSON_LIST[@]}"; do
 for SAMPLE_METHOD in "${SAMPLE_METHODS[@]}"; do
 
-    for triplet in "${TRIPLETS[@]}"; do
+    if [[ "$SAMPLE_METHOD" == "guidance" ]]; then
+        ACTIVE_TRIPLETS=("${TRIPLETS[0]}")
+        ACTIVE_GUIDANCE_RANGES=("0 0")
+        ACTIVE_LOSS_MODES=("${LOSS_MODES[0]}")
+        ACTIVE_GUIDANCE_LR_PATTERNS=("${GUIDANCE_LR_PATTERNS[0]}")
+    else
+        ACTIVE_TRIPLETS=("${TRIPLETS[@]}")
+        ACTIVE_GUIDANCE_RANGES=("${GUIDANCE_RANGES[@]}")
+        ACTIVE_LOSS_MODES=("${LOSS_MODES[@]}")
+        ACTIVE_GUIDANCE_LR_PATTERNS=("${GUIDANCE_LR_PATTERNS[@]}")
+    fi
+
+    for triplet in "${ACTIVE_TRIPLETS[@]}"; do
             # Split triplet into individual variables
             read -r SLICE_WINDOW_SIZE CONTEXT_LENGTH STRIDE <<< "$triplet"
-            for guidance_range in "${GUIDANCE_RANGES[@]}"; do
+            for guidance_range in "${ACTIVE_GUIDANCE_RANGES[@]}"; do
                 # Split guidance range into start and end values (GLOBAL 0..49)
                 read -r GUIDANCE_START GUIDANCE_END <<< "$guidance_range"
                 TRAVEL_TIME="${GUIDANCE_START},${GUIDANCE_END}"
                 for CFG_SCALE in "${CFG_SCALES[@]}"; do
-                    for LOSS_MODE in "${LOSS_MODES[@]}"; do
+                    for LOSS_MODE in "${ACTIVE_LOSS_MODES[@]}"; do
                     for VJEPA_VARIANT in "${VJEPA_VARIANTS[@]}"; do
-                    echo "Config: Method=$SAMPLE_METHOD, Context=$CONTEXT_LENGTH, Stride=$STRIDE, Range=$TRAVEL_TIME, CFG=$CFG_SCALE, LossMode=$LOSS_MODE, VJEPA=$VJEPA_VARIANT"
+                    echo "Config: Method=$SAMPLE_METHOD, GuidanceScale=$GUIDANCE_SCALE, GuidanceFreq=$GUIDANCE_FREQUENCY, CFG=$CFG_SCALE, VJEPA=$VJEPA_VARIANT"
 
                     # Match structure: <OUTPUT_FOLDER>/<group>/<experiment>/<name>.mp4
                     if [[ "$(basename "$BATCH_JSON")" == "physics_iq.json" ]]; then
@@ -110,7 +122,7 @@ for SAMPLE_METHOD in "${SAMPLE_METHODS[@]}"; do
                     mkdir -p "$MODEL_OUTPUT_FOLDER"
 
                     # Loop over LR patterns; pass base output folder and let Python name runs
-                    for GUIDANCE_LR_PATTERN in "${GUIDANCE_LR_PATTERNS[@]}"; do
+                    for GUIDANCE_LR_PATTERN in "${ACTIVE_GUIDANCE_LR_PATTERNS[@]}"; do
                         RUN_OUTPUT_FOLDER="$MODEL_OUTPUT_FOLDER"
                         mkdir -p "$RUN_OUTPUT_FOLDER"
 

--- a/generator_i2v_multinode.py
+++ b/generator_i2v_multinode.py
@@ -46,6 +46,25 @@ def parse_float_range_pair(text: str):
     a, b = (text.split(",", 1) if "," in text else text.split("-", 1))
     return float(a.strip()), float(b.strip())
 
+
+def normalize_vjepa_variant(model_name: str) -> str:
+    alias_map = {
+        "vith": "vith",
+        "vit_huge": "vith",
+        "vitg": "vitg",
+        "vit_giant": "vitg",
+        "vitg384": "vitg384",
+        "vit_giant_384": "vitg384",
+        "vitgac": "vitgac",
+        "vit_giant_ac": "vitgac",
+    }
+    if model_name not in alias_map:
+        raise ValueError(
+            f"Unsupported V-JEPA variant '{model_name}'. "
+            "Use one of: vith, vit_huge, vitg, vit_giant, vitg384, vit_giant_384, vitgac, vit_giant_ac."
+        )
+    return alias_map[model_name]
+
 def save_experiment_metadata(args, experiment_name, experiment_folder):
     """Save experiment metadata as JSON file in the experiment folder."""
 
@@ -74,10 +93,12 @@ def save_experiment_metadata(args, experiment_name, experiment_folder):
             "vjepa_context_frames": context_frames,
             "slice_stride": stride,
             "slice_window_size": window_size,
+            "guidance_scale": getattr(args, 'guidance_scale', None),
             "travel_time": getattr(args, 'travel_time', None),
             "guidance_step_pattern": getattr(args, 'guidance_step_pattern', None),
             "guidance_lr_pattern": getattr(args, 'guidance_lr_pattern', None),
             "guidance_frequency": getattr(args, 'guidance_frequency', None),
+            "vjepa_type": getattr(args, 'vjepa_type', None),
             "vjepa_variant": getattr(args, 'vjepa_variant', None),
             "vjepa_img_size": getattr(args, 'vjepa_img_size', None),
             "vjepa_masking_mode": getattr(args, 'vjepa_masking_mode', None),
@@ -213,6 +234,9 @@ def init_pipeline(args):
     from inference.pipeline.pipeline_w_guidance import MagiPipeline
 
     pipeline = MagiPipeline(args.config_file)
+    pipeline.guidance_scale = getattr(args, "guidance_scale", pipeline.guidance_scale)
+    pipeline.guidance_frequency = getattr(args, "guidance_frequency", pipeline.guidance_frequency)
+    pipeline.vjepa_type = normalize_vjepa_variant(getattr(args, "vjepa_type", args.vjepa_variant))
     return pipeline
 
 def init_vjepa_models(args):
@@ -220,8 +244,9 @@ def init_vjepa_models(args):
     if args.sampling_method != 'rejection':
         return None, None, None
 
-    print(f"Loading V-JEPA models for rejection sampling ({args.vjepa_variant})...")
-    encoder, target_encoder, predictor, img_size = load_vjepa_models_torchhub(args.vjepa_variant)
+    normalized_variant = normalize_vjepa_variant(args.vjepa_variant)
+    print(f"Loading V-JEPA models for rejection sampling ({normalized_variant})...")
+    encoder, target_encoder, predictor, img_size = load_vjepa_models_torchhub(normalized_variant)
     encoder.eval().cuda()
     target_encoder.eval().cuda()
     predictor.eval().cuda()
@@ -549,6 +574,7 @@ def main():
     parser.add_argument('--cfg_scale', type=float, default=6.0, help='Classifier-free guidance scale.')
 
     # Guidance sampling parameters
+    parser.add_argument('--guidance_scale', type=float, default=0.001, help='VJEPA guidance scale.')
     parser.add_argument('--guidance_start', type=int, default=0, help='Timestep to start applying guidance (0..1001).')
     parser.add_argument('--guidance_end', type=int, default=1001, help='Timestep to end applying guidance (0..1001).')
     parser.add_argument('--guidance_rho_scale', type=float, default=6.0, help='[Deprecated] Overall LR scale (use guidance_lr_pattern instead).')
@@ -558,7 +584,8 @@ def main():
     # VJEPA guidance parameters
     parser.add_argument('--guidance_step_pattern', type=str, default='0x3,3x12,2x12,1x23', help='Repeat counts per step bucket.')
     parser.add_argument('--guidance_lr_pattern', type=str, default='3.0x15,2.0x15,1.0x20', help='LR per step bucket.')
-    parser.add_argument('--vjepa_variant', type=str, default='vit_giant', choices=['vit_large','vit_huge','vit_giant','vit_giant_384'])
+    parser.add_argument('--vjepa_variant', type=str, default='vit_giant', choices=['vith', 'vit_huge', 'vitg', 'vit_giant', 'vitg384', 'vit_giant_384', 'vitgac', 'vit_giant_ac'])
+    parser.add_argument('--vjepa_type', type=str, default=None, choices=['vith', 'vit_huge', 'vitg', 'vit_giant', 'vitg384', 'vit_giant_384', 'vitgac', 'vit_giant_ac'], help='Optional override for the MAGI guidance JEPA backbone.')
     parser.add_argument('--vjepa_img_size', type=int, default=256)
     parser.add_argument('--style_weight', type=float, default=1.0)
     parser.add_argument('--vjepa_masking_mode', type=str, default='causal', choices=['causal', 'random'])
@@ -601,6 +628,7 @@ def main():
 
     if args.sampling_method == 'guidance':
         print(f"Guidance parameters:")
+        print(f"  - Scale: {args.guidance_scale}")
         print(f"  - Step pattern: {args.guidance_step_pattern}")
         print(f"  - LR pattern: {args.guidance_lr_pattern}")
         print(f"  - Frequency: {args.guidance_frequency}")

--- a/generator_i2v_multinode.py
+++ b/generator_i2v_multinode.py
@@ -65,6 +65,22 @@ def normalize_vjepa_variant(model_name: str) -> str:
         )
     return alias_map[model_name]
 
+
+def guidance_metadata_only_args(args) -> dict:
+    context_frames, stride, window_size = _resolve_sliding_window_params(args)
+    return {
+        "guidance_start": getattr(args, "guidance_start", None),
+        "guidance_end": getattr(args, "guidance_end", None),
+        "guidance_rho_scale": getattr(args, "guidance_rho_scale", None),
+        "travel_time": getattr(args, "travel_time", None),
+        "guidance_step_pattern": getattr(args, "guidance_step_pattern", None),
+        "guidance_lr_pattern": getattr(args, "guidance_lr_pattern", None),
+        "vjepa_context_frames": context_frames,
+        "slice_stride": stride,
+        "slice_window_size": window_size,
+        "loss_mode": getattr(args, "loss_mode", None),
+    }
+
 def save_experiment_metadata(args, experiment_name, experiment_folder):
     """Save experiment metadata as JSON file in the experiment folder."""
 
@@ -88,23 +104,12 @@ def save_experiment_metadata(args, experiment_name, experiment_folder):
 
     # Add guidance-specific parameters
     if args.sampling_method == 'guidance':
-        context_frames, stride, window_size = _resolve_sliding_window_params(args)
         metadata["parameters"].update({
-            "vjepa_context_frames": context_frames,
-            "slice_stride": stride,
-            "slice_window_size": window_size,
             "guidance_scale": getattr(args, 'guidance_scale', None),
-            "travel_time": getattr(args, 'travel_time', None),
-            "guidance_step_pattern": getattr(args, 'guidance_step_pattern', None),
-            "guidance_lr_pattern": getattr(args, 'guidance_lr_pattern', None),
             "guidance_frequency": getattr(args, 'guidance_frequency', None),
             "vjepa_type": getattr(args, 'vjepa_type', None),
             "vjepa_variant": getattr(args, 'vjepa_variant', None),
-            "vjepa_img_size": getattr(args, 'vjepa_img_size', None),
-            "vjepa_masking_mode": getattr(args, 'vjepa_masking_mode', None),
-            "vjepa_mask_ratio": getattr(args, 'vjepa_mask_ratio', None),
-            "style_weight": getattr(args, 'style_weight', None),
-            "loss_mode": getattr(args, 'loss_mode', None),
+            "legacy_metadata_only_args": guidance_metadata_only_args(args),
         })
 
     # Add rejection sampling parameters
@@ -130,15 +135,14 @@ def get_simple_experiment_name(args):
     if args.sampling_method == 'vanilla':
         name = f"vanilla_{version}_f{args.num_frames}_s{args.num_inference_steps}_cfg{args.cfg_scale}_seed{args.seed}"
     elif args.sampling_method == 'guidance':
-        loss_mode = getattr(args, 'loss_mode', 'mean')
         vjepa_variant = getattr(args, 'vjepa_variant', 'vit_giant')
         # Simplify vjepa variant name for brevity
         vjepa_short = vjepa_variant.replace('vit_', '') if vjepa_variant != 'vit_giant' else ''
 
         name = (
             f"guidance_{version}_f{args.num_frames}_s{args.num_inference_steps}"
-            f"_c{getattr(args, 'vjepa_context_frames', 8)}"
-            f"_cfg{args.cfg_scale}_gsp{getattr(args, 'guidance_step_pattern', '')}_glp{getattr(args, 'guidance_lr_pattern', '')}_gf{getattr(args, 'guidance_frequency', '')}_{loss_mode}_seed{args.seed}"
+            f"_gs{getattr(args, 'guidance_scale', '')}_gf{getattr(args, 'guidance_frequency', '')}"
+            f"_cfg{args.cfg_scale}_seed{args.seed}"
         )
 
         # Add vjepa variant if not default
@@ -575,26 +579,26 @@ def main():
 
     # Guidance sampling parameters
     parser.add_argument('--guidance_scale', type=float, default=0.001, help='VJEPA guidance scale.')
-    parser.add_argument('--guidance_start', type=int, default=0, help='Timestep to start applying guidance (0..1001).')
-    parser.add_argument('--guidance_end', type=int, default=1001, help='Timestep to end applying guidance (0..1001).')
-    parser.add_argument('--guidance_rho_scale', type=float, default=6.0, help='[Deprecated] Overall LR scale (use guidance_lr_pattern instead).')
+    parser.add_argument('--guidance_start', type=int, default=0, help='Legacy option kept for compatibility; not consumed by the current MAGI guidance path.')
+    parser.add_argument('--guidance_end', type=int, default=1001, help='Legacy option kept for compatibility; not consumed by the current MAGI guidance path.')
+    parser.add_argument('--guidance_rho_scale', type=float, default=6.0, help='Legacy option kept for compatibility; not consumed by the current MAGI guidance path.')
     parser.add_argument('--guidance_frequency', type=int, default=5, help='Frequency of guidance updates.')
-    parser.add_argument('--travel_time', type=str, default='3,12', help='Direct guidance range in global steps "start,end" (0..49). Overrides guidance_start/end if provided.')
+    parser.add_argument('--travel_time', type=str, default='3,12', help='Legacy option kept for compatibility; not consumed by the current MAGI guidance path.')
 
     # VJEPA guidance parameters
-    parser.add_argument('--guidance_step_pattern', type=str, default='0x3,3x12,2x12,1x23', help='Repeat counts per step bucket.')
-    parser.add_argument('--guidance_lr_pattern', type=str, default='3.0x15,2.0x15,1.0x20', help='LR per step bucket.')
+    parser.add_argument('--guidance_step_pattern', type=str, default='0x3,3x12,2x12,1x23', help='Legacy option kept for compatibility; not consumed by the current MAGI guidance path.')
+    parser.add_argument('--guidance_lr_pattern', type=str, default='3.0x15,2.0x15,1.0x20', help='Legacy option kept for compatibility; not consumed by the current MAGI guidance path.')
     parser.add_argument('--vjepa_variant', type=str, default='vit_giant', choices=['vith', 'vit_huge', 'vitg', 'vit_giant', 'vitg384', 'vit_giant_384', 'vitgac', 'vit_giant_ac'])
     parser.add_argument('--vjepa_type', type=str, default=None, choices=['vith', 'vit_huge', 'vitg', 'vit_giant', 'vitg384', 'vit_giant_384', 'vitgac', 'vit_giant_ac'], help='Optional override for the MAGI guidance JEPA backbone.')
     parser.add_argument('--vjepa_img_size', type=int, default=256)
     parser.add_argument('--style_weight', type=float, default=1.0)
     parser.add_argument('--vjepa_masking_mode', type=str, default='causal', choices=['causal', 'random'])
-    parser.add_argument('--vjepa_context_frames', type=int, default=8)
+    parser.add_argument('--vjepa_context_frames', type=int, default=8, help='Used by rejection sampling and metadata only; not consumed by the current MAGI guidance path.')
     parser.add_argument('--vjepa_mask_ratio', type=float, default=0.5)
-    parser.add_argument('--slice_window_size', type=int, default=16)
-    parser.add_argument('--slice_stride', type=int, default=4)
+    parser.add_argument('--slice_window_size', type=int, default=16, help='Used by rejection sampling and metadata only; not consumed by the current MAGI guidance path.')
+    parser.add_argument('--slice_stride', type=int, default=4, help='Used by rejection sampling and metadata only; not consumed by the current MAGI guidance path.')
     parser.add_argument('--vae_decode_scale', type=float, default=0.7, help='VAE decode scale factor.')
-    parser.add_argument('--loss_mode', type=str, default='max', choices=['mean', 'max'], help='V-JEPA loss aggregation mode.')
+    parser.add_argument('--loss_mode', type=str, default='max', choices=['mean', 'max'], help='Used by rejection sampling and metadata only; not consumed by the current MAGI guidance path.')
 
     # Rejection sampling parameters (only used when sampling_method='rejection')
     parser.add_argument('--rejection_samples', type=int, default=3,
@@ -629,10 +633,9 @@ def main():
     if args.sampling_method == 'guidance':
         print(f"Guidance parameters:")
         print(f"  - Scale: {args.guidance_scale}")
-        print(f"  - Step pattern: {args.guidance_step_pattern}")
-        print(f"  - LR pattern: {args.guidance_lr_pattern}")
         print(f"  - Frequency: {args.guidance_frequency}")
-        print(f"  - Travel time: {args.travel_time}")
+        print(f"  - V-JEPA backbone: {normalize_vjepa_variant(getattr(args, 'vjepa_type', args.vjepa_variant))}")
+        print("  - Note: legacy guidance tuning flags are metadata-only today and are not consumed by the current MAGI guidance path.")
 
     if args.sampling_method == 'rejection':
         print(f"Rejection sampling enabled:")

--- a/tests/check_guidance_effect.py
+++ b/tests/check_guidance_effect.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Small regression helper to verify that guidance changes the generated video."""
+
+import argparse
+import hashlib
+import sys
+
+import cv2
+import numpy as np
+
+
+def read_video(path: str) -> np.ndarray:
+    cap = cv2.VideoCapture(path)
+    if not cap.isOpened():
+        raise RuntimeError(f"Could not open video: {path}")
+
+    frames = []
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        frames.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+    cap.release()
+
+    if not frames:
+        raise RuntimeError(f"No frames decoded from video: {path}")
+    return np.stack(frames, axis=0)
+
+
+def sha256_digest(x: np.ndarray) -> str:
+    return hashlib.sha256(x.tobytes()).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check that a guided MAGI run differs from the baseline run.")
+    parser.add_argument("--baseline", required=True, help="Path to baseline video (e.g. guidance_scale=0).")
+    parser.add_argument("--guided", required=True, help="Path to guided video (e.g. guidance_scale>0).")
+    parser.add_argument(
+        "--min-mean-diff",
+        type=float,
+        default=1e-6,
+        help="Minimum mean absolute pixel difference required to treat the videos as different.",
+    )
+    args = parser.parse_args()
+
+    baseline = read_video(args.baseline)
+    guided = read_video(args.guided)
+
+    if baseline.shape != guided.shape:
+        print(f"FAIL: video shapes differ: baseline={baseline.shape}, guided={guided.shape}")
+        return 1
+
+    baseline_hash = sha256_digest(baseline)
+    guided_hash = sha256_digest(guided)
+
+    abs_diff = np.abs(baseline.astype(np.float32) - guided.astype(np.float32))
+    mean_diff = float(abs_diff.mean())
+    max_diff = int(abs_diff.max())
+    changed_pixels = int(np.count_nonzero(abs_diff))
+
+    print(f"baseline_sha256={baseline_hash}")
+    print(f"guided_sha256={guided_hash}")
+    print(f"shape={baseline.shape}")
+    print(f"mean_abs_diff={mean_diff:.8f}")
+    print(f"max_abs_diff={max_diff}")
+    print(f"changed_pixels={changed_pixels}")
+
+    if baseline_hash == guided_hash or mean_diff <= args.min_mean_diff:
+        print("FAIL: guidance had no measurable effect on the generated video.")
+        return 1
+
+    print("PASS: guided output differs from the baseline output.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This PR fixes several issues in the MAGI-1 guidance path used by WMReward.

Changes:
- update the `MAGI-1` submodule to the guidance fix commit
- wire `generator_i2v_multinode.py` to the actual MAGI guidance arguments
- fix the documented and scripted MAGI config path
- clarify which legacy guidance CLI flags are metadata-only today
- add a simple regression helper to check that guided and baseline outputs are no longer identical

## Root Cause

There were a few separate problems affecting guidance:

1. `generator_i2v_multinode.py` did not initialize the pipeline guidance attributes (`guidance_scale`, `guidance_frequency`, `vjepa_type`), so the public runner could fail or silently not use the intended settings
2. the guidance code inside MAGI-1 used a hard-coded wrapper config path instead of the active runtime config
3. the JEPA guidance preprocessing did not match the scorer path because the decoded frames were normalized without the `/255` conversion step
4. guidance context was seeded from the oldest clean chunks instead of the most recent ones
5. the extra-clean-chunk path could misalign timestep metadata with the latent chunks
6. the multi-node guidance CLI exposed several legacy knobs as if they controlled MAGI guidance, even though they were not consumed by the current sampler

## What Changed

In MAGI-1:
- use the active runtime config for guidance decoding instead of a hard-coded config file
- add safe default guidance attributes on `MagiPipeline`
- fix JEPA preprocessing to match the scorer path
- use the latest clean chunks as rolling context
- fix extra-clean-chunk timestep bookkeeping

In WMReward:
- pass the active guidance settings through the multi-node runner
- normalize JEPA backbone naming between runner paths
- point the docs and launch script at a real MAGI config file
- make it explicit which legacy guidance flags are metadata-only for the current guidance path
- add `tests/check_guidance_effect.py` as a simple reproduction/regression helper for the “guidance has no effect” report

## Validation

Syntax / script checks:
- `python3` syntax compilation for the updated Python files
- `bash -n generation/generate_i2v_magi1_multinode.sh`

To reproduce the guidance-effect check from issue #8:

```bash
PROMPT="A ball falls from the table onto the floor"
CONFIG="./MAGI-1/example/24B/24B_base_config.json"
INIT="./example/0001_switch-frames_anyFPS_perspective-left_trimmed-ball-and-block-fall.jpg"
OUT="./results/guidance_check"

mkdir -p "$OUT"

torchrun --standalone --nproc_per_node=8 generate_magi1.py \
  --config_file "$CONFIG" \
  --prompt "$PROMPT" \
  --init_image "$INIT" \
  --output_path "$OUT/baseline.mp4" \
  --mode i2v \
  --guidance_scale 0 \
  --guidance_frequency 5

torchrun --standalone --nproc_per_node=8 generate_magi1.py \
  --config_file "$CONFIG" \
  --prompt "$PROMPT" \
  --init_image "$INIT" \
  --output_path "$OUT/guided.mp4" \
  --mode i2v \
  --guidance_scale 0.01 \
  --guidance_frequency 5

python3 tests/check_guidance_effect.py \
  --baseline "$OUT/baseline.mp4" \
  --guided "$OUT/guided.mp4"
